### PR TITLE
Remove the '0' in the get started activity/ Fixed unclickable Button

### DIFF
--- a/app/src/main/java/com/carpark/views/GetStarted.java
+++ b/app/src/main/java/com/carpark/views/GetStarted.java
@@ -202,9 +202,13 @@ public class GetStarted extends BaseActivity {
         intent = new Intent(getApplicationContext(), VerifyNumber.class);
         if (TextUtils.isEmpty(number.getText().toString())) {
             number.setError("Please fill in phone number");
-        } else if (!((Phone.length() < 10) || (Phone.length() > 11))) {
-            cont_btn.setClickable(false);
-            showAlert(fullPhone);
+        } else if (!((Phone.length() < 9) || (Phone.length() > 11))) {
+            if (Phone.startsWith("0")) {
+                number.setError("Remove the '0' in front please ");
+            } else {
+                cont_btn.setClickable(false);
+                showAlert(fullPhone);
+            }
         } else {
             Toast.makeText(GetStarted.this, "Enter a Valid Number", Toast.LENGTH_SHORT).show();
         }
@@ -230,6 +234,7 @@ public class GetStarted extends BaseActivity {
             public void onClick(View view) {
                 sendOTPbar.setVisibility(View.VISIBLE);
                 dialog.dismiss();
+                cont_btn.setClickable(true);
                 verifyNumberIfRegistered(phoneNumber);
 
 
@@ -241,6 +246,15 @@ public class GetStarted extends BaseActivity {
             @Override
             public void onClick(View view) {
                 dialog.dismiss();
+                cont_btn.setClickable(true);
+            }
+
+
+        });
+        dialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
+            @Override
+            public void onDismiss(DialogInterface dialogInterface) {
+                cont_btn.setClickable(true);
             }
         });
 

--- a/app/src/main/res/layout/activity_get_started.xml
+++ b/app/src/main/res/layout/activity_get_started.xml
@@ -75,7 +75,7 @@
                 android:fontFamily="@font/nunito"
                 android:hint="Enter your phone number"
                 android:inputType="phone"
-                android:maxLength="13"
+                android:maxLength="11"
                 android:paddingLeft="8dp"
                 android:textAllCaps="false"
                 android:textColor="#777777"


### PR DESCRIPTION
- Set an error whenever the user types a "0" in from of the number
- Resolved the un-clickability of the cont. button when the dialogue is dismissed.

 